### PR TITLE
after switch to dark mode, the invisible texts now showing.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -721,6 +721,7 @@ section {
 .services .description {
   font-size: 15px;
   line-height: 28px;
+  color: #000000;
   margin-bottom: 0;
 }
 
@@ -951,6 +952,7 @@ section {
 .testimonials .testimonial-item p {
   font-style: italic;
   margin: 0 auto 15px auto;
+  color: #000000;
 }
 .testimonials .swiper-pagination {
   margin-top: 20px;


### PR DESCRIPTION
before:
![EduHub Community - Google Chrome 10_18_2022 12_26_17 PM](https://user-images.githubusercontent.com/86670745/196420984-1ec3a5ac-6d06-4150-9ead-4b2699a6d9f9.png)
after:
![EduHub Community - Google Chrome 10_18_2022 12_32_15 PM](https://user-images.githubusercontent.com/86670745/196421040-698dbe52-c666-44c8-bb84-eb25d3b31c41.png)
before:
![EduHub Community - Google Chrome 10_18_2022 12_26_37 PM](https://user-images.githubusercontent.com/86670745/196421089-3cb566d9-7b71-4b0d-be29-17e2a2e03ecd.png)
after:
![EduHub Community - Google Chrome 10_18_2022 12_32_09 PM](https://user-images.githubusercontent.com/86670745/196421130-c95c9ffd-24d5-4ba0-a205-8fa073a853ef.png)
