### PR TITLE
FIXED #553 Resolving NavBar Overlapping Issue on Gallery Page

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@
 body {
   font-family: "Open Sans", sans-serif;
   color: #444444;
+  padding: 30px;
 }
 
 #blinking {


### PR DESCRIPTION


## Related Issue

Closes #553



## Description
FIXES #553 


## Screenshots
![image](https://github.com/Eduhub-Community/Eduhub-Community.github.io/assets/112367082/a39f30f5-5db1-4d78-9810-04cfcb485909)



## Checklist

Adjusted the CSS properties related to the navigation bar to prevent it from overlapping with the Gallery heading.
Modified the HTML structure to ensure proper rendering of the Gallery page, taking into account different screen sizes and resolutions.
